### PR TITLE
为outputTargets增加overwriteOutputFile配置，实现强行覆盖目标文件的功能

### DIFF
--- a/plugin/src/main/java/io/github/ceragon/protobuf/extension/OutputTarget.java
+++ b/plugin/src/main/java/io/github/ceragon/protobuf/extension/OutputTarget.java
@@ -13,11 +13,15 @@ public class OutputTarget {
     @Internal("生成语言类型")
     String type = "java";
 
-    @Internal("是否预先清理之前生成的文件")
+    @Internal("是否预先清理之前生成的文件夹")
     boolean cleanOutputFolder = true;
+
+    @Internal("是否覆盖之前生成文件")
+    boolean overwriteOutputFile = false;
+
     @Internal("导出目录")
     String outputDirectory;
-;
+
     @Internal("导出的可选项，支持protoc的所有配置")
     String outputOptions;
 

--- a/plugin/src/main/java/io/github/ceragon/protobuf/protoc/util/OutputTargetUtil.java
+++ b/plugin/src/main/java/io/github/ceragon/protobuf/protoc/util/OutputTargetUtil.java
@@ -91,7 +91,7 @@ public class OutputTargetUtil {
             if (inputFile.exists() && inputFile.isDirectory()) {
                 Collection<File> protoFiles = FileUtils.listFiles(inputFile, fileFilter, TrueFileFilter.INSTANCE);
                 for (File protoFile : protoFiles) {
-                    if (target.isCleanOutputFolder()) {
+                    if (target.isCleanOutputFolder() || target.isOverwriteOutputFile()) {
                         processFile(includeDirectoryList, protocCommand, protoFile, targetType, null,
                                 target.getOutputDirectory(), target.getOutputOptions());
                     } else {


### PR DESCRIPTION
当在Untiy项目下使用outputTargets任务生成C# proto代码时，会存在一个左右为难的问题：

1、假如将cleanOutputFolder设置为true，那么目标文件夹会被情况，这导致meta文件也被清除
2、而如果将cleanOutputFolder设置为false，那么该任务又只会处理全新的proto文件，同时不再处理修改过的老的proto文件

基于这个情景，加了一个overwriteOutputFile的配置项，当设置为true时，会强行覆盖目标文件（假如存在的话）。并且overwriteOutputFile默认值为false，因此本次pr是一次向下兼容的修改